### PR TITLE
Fix AttributeError: 'Namespace' object has no attribute 'delete'

### DIFF
--- a/src/tardelta.py
+++ b/src/tardelta.py
@@ -216,8 +216,8 @@ def main():
         output_mode = 'w'
 
     delete_out = None
-    if args.delete:
-        delete_out = open(args.delete, 'wt')
+    if args.deletelist:
+        delete_out = open(args.deletelist, 'wt')
 
     delta(
         tarfile.open(


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "tardelta.py", line 255, in <module>
    sys.exit(main())
  File "tardelta.py", line 219, in main
    if args.delete:
AttributeError: 'Namespace' object has no attribute 'delete'
```
